### PR TITLE
fix(opengraph): cache open graph data

### DIFF
--- a/core-server/app/pom.xml
+++ b/core-server/app/pom.xml
@@ -18,6 +18,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-flyway</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-cache</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>fr.revoicechat</groupId>

--- a/core-server/app/src/main/java/fr/revoicechat/core/web/MessageControllerImpl.java
+++ b/core-server/app/src/main/java/fr/revoicechat/core/web/MessageControllerImpl.java
@@ -12,6 +12,9 @@ import fr.revoicechat.core.technicaldata.message.NewMessage;
 import fr.revoicechat.core.web.api.MessageController;
 import fr.revoicechat.opengraph.OpenGraphSchema;
 import fr.revoicechat.web.mapper.Mapper;
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
 import jakarta.annotation.security.RolesAllowed;
 
 @RolesAllowed(ROLE_USER)
@@ -31,19 +34,22 @@ public class MessageControllerImpl implements MessageController {
   }
 
   @Override
-  public OpenGraphSchema getOpenGraph(final UUID id) {
+  @CacheResult(cacheName = "open-graph-cache")
+  public OpenGraphSchema getOpenGraph(@CacheKey final UUID id) {
     return Mapper.map(new OpenGraphSchemaHolder(messageService.getMessage(id)));
   }
 
   @Override
-  public MessageRepresentation update(UUID id, NewMessage newMessage) {
+  @CacheInvalidate(cacheName = "open-graph-cache")
+  public MessageRepresentation update(@CacheKey UUID id, NewMessage newMessage) {
     var message = messageService.update(id, newMessage);
     messageNotifier.update(message);
     return Mapper.map(message);
   }
 
   @Override
-  public UUID delete(UUID id) {
+  @CacheInvalidate(cacheName = "open-graph-cache")
+  public UUID delete(@CacheKey UUID id) {
     var message = messageService.delete(id);
     messageNotifier.delete(message);
     return message.getId();

--- a/core-server/pom.xml
+++ b/core-server/pom.xml
@@ -29,7 +29,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <skipITs>true</skipITs>
     <compiler-plugin.version>3.15.0</compiler-plugin.version>
-    <quarkus.platform.version>3.34.1</quarkus.platform.version>
+    <quarkus.platform.version>3.34.6</quarkus.platform.version>
     <surefire-plugin.version>3.5.5</surefire-plugin.version>
     <io.smallrye.jandex.version>3.5.3</io.smallrye.jandex.version>
     <org.reflection.version>0.10.2</org.reflection.version>

--- a/core-server/server.docker.exemple.properties
+++ b/core-server/server.docker.exemple.properties
@@ -12,6 +12,12 @@ quarkus.datasource.username=${POSTGRES_USER}
 quarkus.datasource.password=${POSTGRES_PASSWORD}
 
 # ============================================================
+# CACHE
+# ============================================================
+quarkus.cache.caffeine."open-graph-cache".expire-after-write=1H
+quarkus.cache.caffeine."open-graph-cache".maximum-size=1000
+
+# ============================================================
 # SECURITY / JWT
 # ============================================================
 # Where to find keys

--- a/core-server/server.exemple.properties
+++ b/core-server/server.exemple.properties
@@ -12,6 +12,12 @@ quarkus.datasource.username=revoicechat_user
 quarkus.datasource.password=
 
 # ============================================================
+# CACHE
+# ============================================================
+quarkus.cache.caffeine."open-graph-cache".expire-after-write=1H
+quarkus.cache.caffeine."open-graph-cache".maximum-size=1000
+
+# ============================================================
 # SECURITY / JWT
 # ============================================================
 # Where to find keys


### PR DESCRIPTION
## Description
The `GET /message/{id}/open-graph` endpoint fetches Open Graph metadata by calling an external URL synchronously using Jsoup. This makes the endpoint as slow as the external site it hits.


## Proposed Solutions: Cache results
Open Graph data is essentially static. A simple cache avoids redundant fetches.

## Related Issues
Closes https://github.com/revoicechat/revoicechat/issues/69
